### PR TITLE
Push check behaviour change and PMD set to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,18 @@ Features of this action include:
 - Set the severity level you want rules reported at. Levels include error, warning and note (default level is warning).
 - Run PMD Analyser on the files changed. File comparison can be done either based on a git diff or based on the files changed specified on the GitHub pull request.
 
+Note that when you are running this action and making use of the SARIF uploader in the example below, if you are looking to get pull request comments then you will need to run the analyser on push events for the target branch that pull requests are targetting.
+
 ## Example GitHub Action Workflow File
 ```
 name: PMD Static Code Analysis
 on:
   pull_request:
+    branches:
+      - main
   push:
+    branches:
+      - main
 
 jobs:
   pmd-analyser-check:
@@ -32,7 +38,7 @@ jobs:
         id: pmd-analysis
         uses: synergy-au/pmd-analyser-action@v2
         with:
-          pmd-version: '6.34.0'
+          pmd-version: 'latest'
           file-path: './src'
           rules-path: './pmd-ruleset.xml'
           error-rules: 'AvoidDirectAccessTriggerMap,AvoidDmlStatementsInLoops,AvoidHardcodingId'
@@ -90,10 +96,10 @@ If you wish to define rules that log as a note, enter each rule name separated w
 
 ### pmd-version
 
-The version of PMD you would like to run.
+The version of PMD you would like to run. You can either specify latest to always get the newest version, or you can specify a version number like 6.37.0.
 
--   required: true
--   default: '6.33.0'
+-   required: false
+-   default: 'latest'
 
 ### rules-path
 

--- a/action.yml
+++ b/action.yml
@@ -38,14 +38,14 @@ outputs:
 runs:
   using: "composite"
   steps: 
-    - id: branches
+    - id: code
       run: |
         if [ ${{ github.event_name }} == 'pull_request' ]; then
-            echo "::set-output name=target::${{ github.base_ref }}"
-            echo "::set-output name=source::${{ github.head_ref }}"
+            echo "::set-output name=current_code::${{ github.base_ref }}"
+            echo "::set-output name=changed_code::${{ github.head_ref }}"
         else
-            echo "::set-output name=target::${{ github.event.repository.default_branch }}"
-            echo "::set-output name=source::${{ github.ref }}"
+            echo "::set-output name=current_code::${{ github.event.before }}"
+            echo "::set-output name=changed_code::${{ github.event.after }}"
         fi
       shell: bash
     - id: pmd-analysis
@@ -56,8 +56,8 @@ runs:
         FILE_PATH: ${{ inputs.file-path }}
         RULES_PATH: ${{ inputs.rules-path }}
         ANALYSE_ALL_CODE: ${{ inputs.analyse-all-code }}
-        TARGET_BRANCH: ${{ steps.branches.outputs.target }}
-        SOURCE_BRANCH: ${{ steps.branches.outputs.source }}
+        CURRENT_CODE: ${{ steps.code.outputs.current_code }}
+        CHANGED_CODE: ${{ steps.code.outputs.changed_code }}
         ERROR_RULES: ${{ inputs.error-rules }}
         NOTE_RULES: ${{ inputs.note-rules }}
         REPO_NAME: ${{ github.event.repository.full_name }}
@@ -65,3 +65,4 @@ runs:
         AUTH_TOKEN: ${{ inputs.auth-token }}
         FILE_DIFF_TYPE: ${{ inputs.file-diff-type }}
         WORKSPACE: ${{ github.workspace }}/
+        ACTION_EVENT_NAME: ${{ github.event_name }}

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,9 @@ inputs:
     description: 'If you wish to define rules that log as a note, enter each rule name separated with a comma and no spaces. Note that if a note is identified the run will not fail. e.g. ClassNamingConventions,GuardLogStatement'
     required: false
   pmd-version:
-    description: 'The version of PMD you would like to run.'
+    description: 'The version of PMD you would like to run. You can either specify latest to always get the newest version, or you can specify a version number like 6.37.0'
     required: false
-    default: '6.34.0'
+    default: 'latest'
   rules-path:
     description: 'The ruleset file you want to use. PMD uses xml configuration files, called rulesets, which specify which rules to execute on your sources. You can also run a single rule by referencing it using its category and name (more details here). For example, you can check for unnecessary modifiers on Java sources with -R category/java/codestyle.xml/UnnecessaryModifier.'
     required: true

--- a/pmd-analyser.sh
+++ b/pmd-analyser.sh
@@ -1,5 +1,11 @@
 # shellcheck shell=sh
 
+# Check whether to use latest version of PMD
+if [ "$PMD_VERSION" == 'latest' ]; then
+    LATEST_TAG="$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/pmd/pmd/releases/latest | jq --raw-output '.tag_name')"
+    PMD_VERSION="${LATEST_TAG#"pmd_releases/"}"
+fi
+
 # Download PMD
 wget https://github.com/pmd/pmd/releases/download/pmd_releases%2F"${PMD_VERSION}"/pmd-bin-"${PMD_VERSION}".zip
 unzip pmd-bin-"${PMD_VERSION}".zip


### PR DESCRIPTION
Two changes as part of this:

- The push event behaviour is now changed so that it will compare the commit before a push to the last commit after to push. From a file diff perspective I'd say this makes more sense in comparison to the existing logic of comparing the latest commit on two different branches. This also means that we can make use of the SARIF uploader for pull request diffs.
- The ability to specify `latest` as the PMD version you'd like so you can pull straight from the PMD releases. This resolves #3 